### PR TITLE
Add node zone labels according to connected UPS

### DIFF
--- a/software-layer/k8s/infrastructure/production/kustomization.yaml
+++ b/software-layer/k8s/infrastructure/production/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../base/sources/
   - ../base/metallb/
   - ../base/longhorn/
+  - ./node-labels.yaml
   - ./metallb-resources.yaml
 patchesStrategicMerge:
   - ./longhorn-patches.yaml

--- a/software-layer/k8s/infrastructure/production/node-labels.yaml
+++ b/software-layer/k8s/infrastructure/production/node-labels.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-prod-vm01
+  labels:
+    topology.kubernetes.io/zone: ups01
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-prod-vm02
+  labels:
+    topology.kubernetes.io/zone: ups02
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-prod-vm03
+  labels:
+    topology.kubernetes.io/zone: ups01
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-prod-vm04
+  labels:
+    topology.kubernetes.io/zone: ups02
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-prod-vm05
+  labels:
+    topology.kubernetes.io/zone: ups01
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-pi01
+  labels:
+    topology.kubernetes.io/zone: ups01
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-pi03
+  labels:
+    topology.kubernetes.io/zone: ups01

--- a/software-layer/k8s/infrastructure/staging/kustomization.yaml
+++ b/software-layer/k8s/infrastructure/staging/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../base/sources/
   - ../base/metallb/
   - ../base/longhorn/
+  - ./node-labels.yaml
   - ./metallb-resources.yaml
 patchesStrategicMerge:
   - ./longhorn-patches.yaml

--- a/software-layer/k8s/infrastructure/staging/node-labels.yaml
+++ b/software-layer/k8s/infrastructure/staging/node-labels.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-staging-vm01
+  labels:
+    topology.kubernetes.io/zone: ups01
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-staging-vm02
+  labels:
+    topology.kubernetes.io/zone: ups02
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-staging-vm03
+  labels:
+    topology.kubernetes.io/zone: ups01
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-staging-vm04
+  labels:
+    topology.kubernetes.io/zone: ups02
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-staging-vm05
+  labels:
+    topology.kubernetes.io/zone: ups01
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-staging-vm05
+  labels:
+    topology.kubernetes.io/zone: ups01
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-staging-vm05
+  labels:
+    topology.kubernetes.io/zone: ups01
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-pi02
+  labels:
+    topology.kubernetes.io/zone: ups01
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k3s-pi04
+  labels:
+    topology.kubernetes.io/zone: ups01


### PR DESCRIPTION
By adding zone labels, "Longhorn will always try to schedule the new replica on a new node with a new zone..." For details, see https://longhorn.io/docs/1.3.2/volumes-and-nodes/scheduling/