### PR TITLE
Reorganize Terraform files

### DIFF
--- a/infrastructure-layer/terraform/main.tf
+++ b/infrastructure-layer/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   cloud {
     organization = "bcbrookman"
     workspaces {
-      name = "homelab"
+      tags = ["homelab"]
     }
   }
   required_providers {

--- a/infrastructure-layer/terraform/main.tf
+++ b/infrastructure-layer/terraform/main.tf
@@ -21,27 +21,27 @@ data "sops_file" "tfvars" {
 
 variable "pm_api_url" {
   sensitive = true
-  default = "https://pve:8006/api2/json"
+  default   = "https://pve:8006/api2/json"
 }
 
 variable "pm_api_token_id" {
   sensitive = true
-  default = "user@pam!token"
+  default   = "user@pam!token"
 }
 
 variable "pm_api_token_secret" {
   sensitive = true
-  default = "token"
+  default   = "token"
 }
 
 variable "sshkeys" {
   sensitive = true
-  default = "ssh-public-key"
+  default   = "ssh-public-key"
 }
 
 provider "proxmox" {
-  pm_api_url = data.sops_file.tfvars.data["pm_api_url"]
-  pm_api_token_id = data.sops_file.tfvars.data["pm_api_token_id"]
+  pm_api_url          = data.sops_file.tfvars.data["pm_api_url"]
+  pm_api_token_id     = data.sops_file.tfvars.data["pm_api_token_id"]
   pm_api_token_secret = data.sops_file.tfvars.data["pm_api_token_secret"]
-  pm_tls_insecure = true
+  pm_tls_insecure     = true
 }

--- a/platform-layer/terraform/k3s-vms.tf
+++ b/platform-layer/terraform/k3s-vms.tf
@@ -1,75 +1,21 @@
-resource "proxmox_vm_qemu" "k3s-production" {
-  count = 5
-  ciuser = "brian"
-  name = "k3s-prod-vm0${count.index + 1}"
-  target_node = "pve0${count.index % 5 + 1}"
-  clone = "debian-10-genericcloud-amd64-20211011-792-pve0${count.index % 5 + 1}"
-  agent = 1
-  os_type = "cloud-init"
-  cores = 4
-  sockets = 1
-  cpu = "host"
-  memory = 10240
-  scsihw = "virtio-scsi-pci"
-  onboot = true
-  disk {
-    size = "50G"
-    type = "scsi"
-    storage = "local-lvm"
-  }
-  network {
-    model = "virtio"
-    bridge = "vmbr0"
-    tag = 20
-  }
-  ipconfig0 = "ip=192.168.20.13${count.index + 1}/24,gw=192.168.20.1,ip6=auto"
-  serial {
-    id = 0
-    type = "socket"
-  }
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [
-      network,
-    ]
-  }
-  sshkeys = data.sops_file.tfvars.data["sshkeys"]
+module "k3s-production" {
+  source               = "./modules/k3s-cluster"
+  name_prefix          = "k3s-prod-vm"
+  net_cidr_prefix      = "192.168.20.0/24"
+  net_gateway_addr     = "192.168.20.1"
+  net_starting_hostnum = 131
+  net_vlan             = 20
+  sshkeys              = data.sops_file.tfvars.data["sshkeys"]
+  user                 = "brian"
 }
 
-resource "proxmox_vm_qemu" "k3s-staging" {
-  count = 5
-  ciuser = "brian"
-  name = "k3s-staging-vm0${count.index + 1}"
-  target_node = "pve0${count.index % 5 + 1}"
-  clone = "debian-10-genericcloud-amd64-20211011-792-pve0${count.index % 5 + 1}"
-  agent = 1
-  os_type = "cloud-init"
-  cores = 4
-  sockets = 1
-  cpu = "host"
-  memory = 10240
-  scsihw = "virtio-scsi-pci"
-  onboot = true
-  disk {
-    size = "50G"
-    type = "scsi"
-    storage = "local-lvm"
-  }
-  network {
-    model = "virtio"
-    bridge = "vmbr0"
-    tag = 20
-  }
-  ipconfig0 = "ip=192.168.20.14${count.index + 1}/24,gw=192.168.20.1,ip6=auto"
-  serial {
-    id = 0
-    type = "socket"
-  }
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes = [
-      network,
-    ]
-  }
-  sshkeys = data.sops_file.tfvars.data["sshkeys"]
+module "k3s-staging" {
+  source               = "./modules/k3s-cluster"
+  name_prefix          = "k3s-staging-vm"
+  net_cidr_prefix      = "192.168.20.0/24"
+  net_gateway_addr     = "192.168.20.1"
+  net_starting_hostnum = 141
+  net_vlan             = 20
+  sshkeys              = data.sops_file.tfvars.data["sshkeys"]
+  user                 = "brian"
 }

--- a/platform-layer/terraform/modules/k3s-cluster/main.tf
+++ b/platform-layer/terraform/modules/k3s-cluster/main.tf
@@ -1,0 +1,106 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source = "telmate/proxmox"
+    }
+  }
+}
+
+variable "cores" {
+  type    = number
+  default = 4
+}
+
+variable "disk_size" {
+  type    = string
+  default = "50G"
+}
+
+variable "memory" {
+  type    = number
+  default = 10240
+}
+
+variable "nodes" {
+  type    = number
+  default = 5
+}
+
+variable "name_prefix" {
+  type = string
+}
+
+variable "net_cidr_prefix" {
+  type = string
+}
+
+variable "net_gateway_addr" {
+  type = string
+}
+
+variable "net_starting_hostnum" {
+  type = number
+}
+
+variable "net_vlan" {
+  type = number
+}
+
+variable "sshkeys" {
+  type      = string
+  sensitive = true
+}
+
+variable "user" {
+  type      = string
+  sensitive = true
+}
+
+locals {
+  net_cidr_mask   = split("/", var.net_cidr_prefix)[1]
+  clone_vm_prefix = "debian-10-genericcloud-amd64-20211011-792"
+}
+
+resource "proxmox_vm_qemu" "k3s-vm" {
+  count       = var.nodes
+  ciuser      = var.user
+  name        = "${var.name_prefix}0${count.index + 1}"
+  target_node = "pve0${count.index % var.nodes + 1}"
+  clone       = "${local.clone_vm_prefix}-pve0${count.index % var.nodes + 1}"
+  full_clone  = true
+  agent       = 1
+  os_type     = "cloud-init"
+  cores       = var.cores
+  sockets     = 1
+  cpu         = "host"
+  memory      = var.memory
+  scsihw      = "virtio-scsi-pci"
+  onboot      = true
+  disk {
+    size    = var.disk_size
+    type    = "scsi"
+    storage = "local-lvm"
+  }
+  network {
+    model  = "virtio"
+    bridge = "vmbr0"
+    tag    = 20
+  }
+  ipconfig0 = join(",",
+    [
+      "ip=${cidrhost(var.net_cidr_prefix, var.net_starting_hostnum + count.index)}/${local.net_cidr_mask}",
+      "gw=${var.net_gateway_addr}"
+    ]
+  )
+  serial {
+    id   = 0
+    type = "socket"
+  }
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [
+      network,
+    ]
+  }
+  sshkeys = var.sshkeys
+}

--- a/platform-layer/terraform/other-vms.tf
+++ b/platform-layer/terraform/other-vms.tf
@@ -1,25 +1,25 @@
 resource "proxmox_vm_qemu" "plex01" {
-  name = "plex01"
+  name        = "plex01"
   target_node = "pve04"
-  full_clone = false
-  agent = 1
-  cores = 2
-  sockets = 1
-  cpu = "host"
-  memory = 8192
-  balloon = 2048
-  scsihw = "virtio-scsi-pci"
-  onboot = true
-  boot = "order=scsi0;net0"
+  full_clone  = false
+  agent       = 1
+  cores       = 2
+  sockets     = 1
+  cpu         = "host"
+  memory      = 8192
+  balloon     = 2048
+  scsihw      = "virtio-scsi-pci"
+  onboot      = true
+  boot        = "order=scsi0;net0"
   disk {
-    size = "32G"
-    type = "scsi"
+    size    = "32G"
+    type    = "scsi"
     storage = "local-lvm"
   }
   network {
-    model = "virtio"
+    model  = "virtio"
     bridge = "vmbr0"
-    tag = 20
+    tag    = 20
   }
   lifecycle {
     prevent_destroy = true
@@ -30,27 +30,27 @@ resource "proxmox_vm_qemu" "plex01" {
 }
 
 resource "proxmox_vm_qemu" "docker01" {
-  name = "docker01"
+  name        = "docker01"
   target_node = "pve02"
-  full_clone = false
-  agent = 1
-  cores = 2
-  sockets = 1
-  cpu = "host"
-  memory = 4096
-  scsihw = "virtio-scsi-pci"
-  onboot = true
-  boot = "order=scsi0;net0"
+  full_clone  = false
+  agent       = 1
+  cores       = 2
+  sockets     = 1
+  cpu         = "host"
+  memory      = 4096
+  scsihw      = "virtio-scsi-pci"
+  onboot      = true
+  boot        = "order=scsi0;net0"
   disk {
-    size = "32G"
-    type = "scsi"
+    size    = "32G"
+    type    = "scsi"
     storage = "local-lvm"
     discard = "on"
   }
   network {
-    model = "virtio"
+    model  = "virtio"
     bridge = "vmbr0"
-    tag = 20
+    tag    = 20
   }
   lifecycle {
     # prevent_destroy = true


### PR DESCRIPTION
- Split up Terraform state into separate workspaces for each layer
- Move K3s VM definitions into a Terraform module for better reusability
- Reformat Terraform files using `terraform fmt` for better readability

