### PR TITLE
Customize Traefik Ingress configuration

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -108,4 +108,4 @@ tasks:
         docker run -i --rm ghcr.io/yannh/kubeconform:latest-alpine
         -summary
         -schema-location default
-        -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{`{{.Group}}`}}/{{`{{.ResourceKind}}`}}_{{`{{.ResourceAPIVersion}}`}}.json
+        -schema-location https://raw.githubusercontent.com/bcbrookman/CRDs-catalog/main/{{`{{.Group}}`}}/{{`{{.ResourceKind}}`}}_{{`{{.ResourceAPIVersion}}`}}.json

--- a/software-layer/k8s/infrastructure/production/kustomization.yaml
+++ b/software-layer/k8s/infrastructure/production/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./metallb/
   - ./namespaces.yaml
   - ./nodes.yaml
+  - ./traefik/

--- a/software-layer/k8s/infrastructure/production/traefik/helmchartconfigs.yaml
+++ b/software-layer/k8s/infrastructure/production/traefik/helmchartconfigs.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+spec:
+  valuesContent: |-
+    deployment:
+      kind: DaemonSet
+    service:
+      spec:
+        loadBalancerIP: "192.168.20.210"
+        externalTrafficPolicy: Local

--- a/software-layer/k8s/infrastructure/production/traefik/kustomization.yaml
+++ b/software-layer/k8s/infrastructure/production/traefik/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./helmchartconfigs.yaml

--- a/software-layer/k8s/infrastructure/staging/kustomization.yaml
+++ b/software-layer/k8s/infrastructure/staging/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./metallb/
   - ./namespaces.yaml
   - ./nodes.yaml
+  - ./traefik/

--- a/software-layer/k8s/infrastructure/staging/traefik/helmchartconfigs.yaml
+++ b/software-layer/k8s/infrastructure/staging/traefik/helmchartconfigs.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+spec:
+  valuesContent: |-
+    deployment:
+      kind: DaemonSet
+    service:
+      spec:
+        loadBalancerIP: "192.168.20.230"
+        externalTrafficPolicy: Local

--- a/software-layer/k8s/infrastructure/staging/traefik/kustomization.yaml
+++ b/software-layer/k8s/infrastructure/staging/traefik/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./helmchartconfigs.yaml


### PR DESCRIPTION
- Configures Traefik to run as a DaemonSet for redundancy
- Use local externalTrafficPolicy to avoid potentially unnecessary proxying
- Sets static IPs for the LoadBalancer service so that DNS records can be created appropriately
