### PR TITLE
Use Proxmox VE native dark mode

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -62,8 +62,8 @@ tasks:
     deps:
       - common:general-depends
       - common:ansible-depends
-    cmds:
-      - ansible-galaxy install --force --role-file ansible/requirements.yaml
+    # cmds:
+    #   - ansible-galaxy install --force --role-file ansible/requirements.yaml
 
   infrastructure-layer:lint:
     desc: Lint all infrastructure layer files

--- a/infrastructure-layer/ansible/playbooks/config_proxmox_servers.yaml
+++ b/infrastructure-layer/ansible/playbooks/config_proxmox_servers.yaml
@@ -22,6 +22,3 @@
         state: present
         update_cache: false
       notify: Update apt cache
-
-  roles:
-    - notmycloud.pve_discord_dark

--- a/infrastructure-layer/ansible/requirements.yaml
+++ b/infrastructure-layer/ansible/requirements.yaml
@@ -1,5 +1,0 @@
-# Ansible requirements file
----
-roles:
-  - name: notmycloud.pve_discord_dark
-    version: main


### PR DESCRIPTION
Proxmox VE 7.4 introduced dark mode natively. This PR removes the notmycloud/pve_discord_dark Ansible role as it is no longer needed.