### PR TITLE
Use default K8s storageClass

### DIFF
--- a/platform-layer/ansible/inventory/production/group_vars/k3s_cluster.sops.yaml
+++ b/platform-layer/ansible/inventory/production/group_vars/k3s_cluster.sops.yaml
@@ -1,12 +1,12 @@
-firewall_state: stopped
-firewall_enabled_at_boot: false
-systemd_dir: /etc/systemd/system
-k3s_version: v1.23.4+k3s1
-k3s_token: ENC[AES256_GCM,data:cI3dBMk0iWl0863CwgoJ15zEhGH3/HtqSQLwB7A79vBeXtMR69F5ikwMx72+lnN6Izo=,iv:13bfCt/CjnWOSi44aEPZiLj5aLFV19R5EZsLHellwLg=,tag:FSTqZUYyrlF64ZT9E8JLeg==,type:str]
-extra_server_args: --disable servicelb --tls-san 192.168.0.1
-extra_agent_args: null
 apiserver_endpoint: 192.168.0.1
 apiserver_port: 6443
+extra_agent_args: null
+extra_server_args: --disable servicelb --disable local-storage --tls-san 192.168.0.1
+firewall_enabled_at_boot: false
+firewall_state: stopped
+k3s_token: ENC[AES256_GCM,data:ap4eZhpGibH8QUxgVKtkqSXoRx5jDXKJ8k+YajeX3SDdxH3QrSFim3TVEYony8qI0yg=,iv:ClzCcZtZouskUXyp9x9BLCORN+DXaY0of6f0ggIxa/U=,tag:BzaI64BoOgxsJ3HPxX3nOQ==,type:str]
+k3s_version: v1.23.4+k3s1
+systemd_dir: /etc/systemd/system
 sops:
     kms: []
     gcp_kms: []
@@ -16,14 +16,14 @@ sops:
         - recipient: age1azf8jz2rq6upyktxe0ntqnlnpwlsmuspgqy3ak3rh609vqk2recqdfznyk
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvYTlaZEM3TEp0SW5CdnBU
-            dit0dEVKMVVPT2Z0bEkrQkR1MkNYejNNbXlnCmVyc1ZsSGtSV1o2d25tdUNWWnVk
-            THZKY1U4UEMzaWl0TjhCS0p5SFNiZU0KLS0tIHJjdE5FNHlkY1IwMWV2V2poZkkv
-            M3dqVndDenFoYU44T091cTEyRkdYSHcKQPE3XKJl03XHZjn9vRkqndw8+2KueU0P
-            WDOie3quUBWeA1HpE/Q/68gRGqPHun26EeIObphZyPK8Ipuc/jAwxg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1K0VLK01aYVhLUmdyeXVF
+            cktuVWVHTU9iTzdNYUxETmRZdEtoaVRzTmhvCmpMZnhJSWZKQ1ZvcVVWOFE2Mm93
+            TWNIU0wzZktlbGlCTTFNK3hlUFh2OGsKLS0tIHVXYTBhd2tUWVc3WVdlNFg5Um1v
+            ZDh3NDd5YVlQQmU2b1g0cFpwK3Y2MUUKZMPx0EjpYLwaUkSYz8yBPeDLRwpgqArx
+            Y0hu77A/abYnp8L4Jz48SV0k7AGTig0SKoQ5oTrObmgrwuG+C0hE0A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-12-08T19:58:17Z"
-    mac: ENC[AES256_GCM,data:38SRip+w3dLV4iCr/p4z4+YMJPNFr3Pvh710rocYbtayvMhBuKiaBXlbpVpxAunIsaOn10r/AMWVs1tPiyspA46TGtaB+IihO73vjcd0KJheLUFSRK/ig1RegZEycEVk7WF/40rYiZMnlUPHb6VYhMSu1PAY4b+arUW99Pzbuf4=,iv:RwMPfV84CRl+MNBZl9LHIpc3mekXmv6RPe/Gxj4Oo+I=,tag:Vf6jIGZapQYp5gQrqKe+0g==,type:str]
+    lastmodified: "2023-04-05T13:52:48Z"
+    mac: ENC[AES256_GCM,data:okT7b/Muwe8edUQhgFgxE9Oi+RzbxwhCCEOfHJ2woyGJpnOrhLISu0gzqlVHvGtbZYW3e/lkIivv/PE64pBAzQPcT3rcfqgutg0LGdISNw+VJlTbosb2J6J2BeRKt/miknqvgGNPmU8IDocZt5ycNbnT6MRS0p5qhwqR7OeMCEo=,iv:dTudM3bs7Dck1G16x9AriwyYlNTfFPg00huSMdFEl58=,tag:Pokjhqb/05WUYN73YYAi1w==,type:str]
     pgp: []
     encrypted_regex: (?i)user|pass|secret|key|token|^data$|^stringData$
     version: 3.7.3

--- a/platform-layer/ansible/inventory/staging/group_vars/k3s_cluster.sops.yaml
+++ b/platform-layer/ansible/inventory/staging/group_vars/k3s_cluster.sops.yaml
@@ -1,12 +1,12 @@
-firewall_state: stopped
-firewall_enabled_at_boot: false
-systemd_dir: /etc/systemd/system
-k3s_version: v1.23.4+k3s1
-k3s_token: ENC[AES256_GCM,data:q0aq0GWrvW04BBoBqwzNs3kuYdzQLu1br6ibkf2Bs1ShVU8elQo/+GkiIUo6skCbIQA=,iv:sxn59soi1UOsJH+fpmXeCYz2gniq1j9SVtftvCmaJno=,tag:HwAGMozWLa6wQJvnNiP92A==,type:str]
-extra_server_args: --disable servicelb --tls-san 192.168.0.1
-extra_agent_args: null
 apiserver_endpoint: 192.168.0.1
 apiserver_port: 7443
+extra_agent_args: null
+extra_server_args: --disable servicelb --disable local-storage --tls-san 192.168.0.1
+firewall_enabled_at_boot: false
+firewall_state: stopped
+k3s_token: ENC[AES256_GCM,data:z2J7Z48AC+CiyxX3dw8Yx0Tnnn3sQLuno3CFKjX2iIUlUxBsomw0nnrZRP4+ARK5uUc=,iv:Cw3/VtUri74sOw6OogL/suvt9Y0zKs4a/5mv1Q3/do0=,tag:xcpamU/UuzDlHnfLMwIb8w==,type:str]
+k3s_version: v1.23.4+k3s1
+systemd_dir: /etc/systemd/system
 sops:
     kms: []
     gcp_kms: []
@@ -16,14 +16,14 @@ sops:
         - recipient: age1azf8jz2rq6upyktxe0ntqnlnpwlsmuspgqy3ak3rh609vqk2recqdfznyk
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBVnd5bmdmVG40NFJ0cHBo
-            UEJ0TWdUYktHaG8zZDVqL0VUN25pSTVoMnh3CkhPZWNlUHgvUDd5dnlmODJaQkxU
-            cUJ1dmF3OVI2enZWZkYyY0RLUlFBOEEKLS0tIGJUcEE2cTFXK3EyV3ZSTmVuU0xu
-            WEsrYlZ2NjlLbkFvOUVTYVVwNSt2WjQKVnpDbmHqMjCHim+x0HWId7Sq+pNKrqMt
-            LzgWxe7h7tE8aKjWorXFMZ/5guqhwGhDKApTFG/fUktZPH+prFKx4g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2UDVPZkFUMk1JM1dJOXF0
+            QnNsR0d1NE9YTjhmYmV6M3ZhNGxRcEVlL20wCklOUFBud3NYc2xibG5iR0RmQ3p2
+            TUdoYlZhT29zejZrN3M5ZW5ZbkFQUVUKLS0tIGs5WEg0cHIvK1RnWEUvRkJKWUtG
+            aHFMQytnQkRvSit2cTVVMVhXVkllanMKEK6ELpN8i2ztr+P9phOLvflOrNLMAItk
+            YTayI+9bZXBsQ/ZtT5L33FOUhZH9DEPkbFZUu6SRCDY00tPHXCS60w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-12-08T19:57:43Z"
-    mac: ENC[AES256_GCM,data:9EwbLnGaWG+YxoukdytzF4GJfq6CjyCgqmYb3GCXe+FqMT/jYZrQNz2lvV0x8F4wgx/AAmdt2Yl2o8q+VDvLH+DPaS7iaba6RYDH/Qdja8NVj/+P/XSL8yFX9ZGZMdutYefhoLH7rwcrCrFNZ599IPSBcahlWmYKOe9J00aXW+M=,iv:2NNRrQCDihoL5sCuTEzBkHeWPDHM0DiYvkroPyULQ/I=,tag:dMZa6lWu0+s8V25Vw10WIg==,type:str]
+    lastmodified: "2023-04-05T13:58:16Z"
+    mac: ENC[AES256_GCM,data:hbCnewN1Wb832ZjcZZjLa9XevKglXOGiMU8ZcSSmmpv8avHt+TlA9FwnnV0EnDlUnxOLNpc3ZC8/a6L9Gv9VxA81IJAQl7zQNkwdlafwY/2kkRAyBskEtnNGaJ92RshPUI57pLbGUgfVkQ6a0XLC788cJCC538kQfkQQT6Xq2wI=,iv:Srjrajpu5SeMwEHm3LWLf8wFSC7qio3HeK+pkPjnGTg=,tag:+ul926qFxxL3WMj0atV/RA==,type:str]
     pgp: []
     encrypted_regex: (?i)user|pass|secret|key|token|^data$|^stringData$
     version: 3.7.3

--- a/software-layer/k8s/apps/base/tautulli/persistentvolumeclaims.yaml
+++ b/software-layer/k8s/apps/base/tautulli/persistentvolumeclaims.yaml
@@ -7,7 +7,6 @@ metadata:
     app: tautulli
   name: tautulli-config
 spec:
-  storageClassName: longhorn
   accessModes:
     - ReadWriteOnce
   resources:

--- a/software-layer/k8s/apps/base/unifi/persistentvolumeclaims.yaml
+++ b/software-layer/k8s/apps/base/unifi/persistentvolumeclaims.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn
   resources:
     requests:
       storage: 500Mi

--- a/software-layer/k8s/apps/base/uptime-kuma/persistentvolumeclaims.yaml
+++ b/software-layer/k8s/apps/base/uptime-kuma/persistentvolumeclaims.yaml
@@ -7,7 +7,6 @@ metadata:
     app: uptime-kuma
   name: uptime-kuma-data
 spec:
-  storageClassName: longhorn
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
Disables the K3s built-in local-storage provider to ensure that longhorn is the only and default storage class. Then  removes all `storageClassName` declarations from `persistentVolumeClaim` manifests. This fixes #37 