### PR TITLE
Fix missing docs overview content introduced in #51

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -32,4 +32,5 @@ markdown_extensions:
       absolute: false
       base_path: "/"
       relative_path: /docs/content
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      restrict_base_path: false


### PR DESCRIPTION
Due to a breaking security fix in pymdown-extensions 10.0.0, snippets not under the base path are not included. Set restrict_base_path to false to use legacy behavior.