### PR TITLE
Fix bug in flux-image-update-auto-pr.yaml

### DIFF
--- a/.github/workflows/flux-image-update-auto-pr.yaml
+++ b/.github/workflows/flux-image-update-auto-pr.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   Auto-PR:
-    if: ${{ startsWith(github.head_ref, 'fluxcdbot/') }}
+    if: ${{ startsWith(github.ref_name, 'fluxcdbot/') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The github.head_ref variable is only set when the trigger is either pull_request or pull_request_target. 

https://docs.github.com/en/actions/learn-github-actions/variables