### PR TITLE
Use an emptyDir volume for Plex's Cache directory

### DIFF
--- a/software-layer/k8s/apps/base/plex/resources/deployments.yaml
+++ b/software-layer/k8s/apps/base/plex/resources/deployments.yaml
@@ -55,6 +55,8 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: plex-config
+            - mountPath: /config/Library/Application Support/Plex Media Server/Cache
+              name: plex-config-cache
             - mountPath: /media
               name: plex-media
             - mountPath: /transcodes
@@ -78,3 +80,6 @@ spec:
         - emptyDir:
             medium: Memory
           name: plex-transcodes
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: plex-config-cache


### PR DESCRIPTION
The /config/Library/Application Support/Plex Media Server/Cache directory can occasionally consume all space on the volume. It is also unnecessary to replicate or backup this data so treating it as temporary with an emptyDir volume is preferred.