### PR TITLE
Increase Plex config PVC size

### DIFF
--- a/software-layer/k8s/apps/base/plex/resources/persistentvolumeclaims.yaml
+++ b/software-layer/k8s/apps/base/plex/resources/persistentvolumeclaims.yaml
@@ -10,5 +10,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: 8Gi
 status: {}


### PR DESCRIPTION
While a future solution may still be needed, Plex config storage needs continue to grow despite excluding cache, and transcode directories.