### PR TITLE
Fix Flux image update commit templates

### DIFF
--- a/software-layer/k8s/apps/base/home-assistant/updates/updateautomations.yaml
+++ b/software-layer/k8s/apps/base/home-assistant/updates/updateautomations.yaml
@@ -31,7 +31,12 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+      messageTemplate: |
+        {{ if .Updated.Images -}}
+          Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+        {{ else -}}
+          Unspecified change by {{ .AutomationObject }} ImageUpdateAutomation
+        {{ end -}}
     push:
       branch: fluxcdbot/updates/home-assistant
   interval: 10m0s

--- a/software-layer/k8s/apps/base/pi-hole/updates/updateautomations.yaml
+++ b/software-layer/k8s/apps/base/pi-hole/updates/updateautomations.yaml
@@ -34,7 +34,12 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+      messageTemplate: |
+        {{ if .Updated.Images -}}
+          Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+        {{ else -}}
+          Unspecified change by {{ .AutomationObject }} ImageUpdateAutomation
+        {{ end -}}
     push:
       branch: fluxcdbot/updates/pi-hole
   interval: 10m0s

--- a/software-layer/k8s/apps/base/plex/updates/updateautomations.yaml
+++ b/software-layer/k8s/apps/base/plex/updates/updateautomations.yaml
@@ -31,7 +31,12 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+      messageTemplate: |
+        {{ if .Updated.Images -}}
+          Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+        {{ else -}}
+          Unspecified change by {{ .AutomationObject }} ImageUpdateAutomation
+        {{ end -}}
     push:
       branch: fluxcdbot/updates/plex
   interval: 10m0s

--- a/software-layer/k8s/apps/base/tautulli/updates/updateautomations.yaml
+++ b/software-layer/k8s/apps/base/tautulli/updates/updateautomations.yaml
@@ -31,7 +31,12 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+      messageTemplate: |
+        {{ if .Updated.Images -}}
+          Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+        {{ else -}}
+          Unspecified change by {{ .AutomationObject }} ImageUpdateAutomation
+        {{ end -}}
     push:
       branch: fluxcdbot/updates/tautulli
   interval: 10m0s

--- a/software-layer/k8s/apps/base/unifi/updates/updateautomations.yaml
+++ b/software-layer/k8s/apps/base/unifi/updates/updateautomations.yaml
@@ -31,7 +31,12 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+      messageTemplate: |
+        {{ if .Updated.Images -}}
+          Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+        {{ else -}}
+          Unspecified change by {{ .AutomationObject }} ImageUpdateAutomation
+        {{ end -}}
     push:
       branch: fluxcdbot/updates/unifi
   interval: 10m0s

--- a/software-layer/k8s/apps/base/uptime-kuma/updates/updateautomations.yaml
+++ b/software-layer/k8s/apps/base/uptime-kuma/updates/updateautomations.yaml
@@ -33,7 +33,12 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+      messageTemplate: |
+        {{ if .Updated.Images -}}
+          Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+        {{ else -}}
+          Unspecified change by {{ .AutomationObject }} ImageUpdateAutomation
+        {{ end -}}
     push:
       branch: fluxcdbot/updates/uptime-kuma
   interval: 10m0s

--- a/software-layer/k8s/apps/base/wizarr/updates/updateautomations.yaml
+++ b/software-layer/k8s/apps/base/wizarr/updates/updateautomations.yaml
@@ -31,7 +31,12 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+      messageTemplate: |
+        {{ if .Updated.Images -}}
+          Bump {{ (index .Updated.Images 0).Repository }} to {{ (index .Updated.Images 0).Identifier }}
+        {{ else -}}
+          Unspecified change by {{ .AutomationObject }} ImageUpdateAutomation
+        {{ end -}}
     push:
       branch: fluxcdbot/updates/wizarr
   interval: 10m0s


### PR DESCRIPTION
Add a conditional to check whether an image update has been made. Without this conditional, Flux reconciliation fails with an index out of range error.