### PR TITLE
fix(swl): reorder infrastructure kustomization resources

### DIFF
--- a/software-layer/k8s/infrastructure/base/longhorn/kustomization.yaml
+++ b/software-layer/k8s/infrastructure/base/longhorn/kustomization.yaml
@@ -3,6 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: longhorn-system
 resources:
-  - ./backuptargets.yaml
-  - ./services.yaml
   - ./helmreleases.yaml
+  - ./services.yaml
+  - ./backuptargets.yaml

--- a/software-layer/k8s/infrastructure/base/sources/kustomization.yaml
+++ b/software-layer/k8s/infrastructure/base/sources/kustomization.yaml
@@ -2,6 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./prometheus-community/
   - ./longhorn/
   - ./metallb/
+  - ./prometheus-community/

--- a/software-layer/k8s/infrastructure/production/kustomization.yaml
+++ b/software-layer/k8s/infrastructure/production/kustomization.yaml
@@ -2,10 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./namespaces.yaml
   - ../base/sources/
   - ./cert-manager/
   - ./longhorn/
   - ./metallb/
-  - ./namespaces.yaml
-  - ./nodes.yaml
   - ./traefik/
+  - ./nodes.yaml

--- a/software-layer/k8s/infrastructure/talos3203/kustomization.yaml
+++ b/software-layer/k8s/infrastructure/talos3203/kustomization.yaml
@@ -2,10 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./namespaces.yaml
   - ../base/sources/
   - ./longhorn/
   - ./metallb/
-  - ./namespaces.yaml
 patches:
   - target:
       kind: HelmRepository


### PR DESCRIPTION
Reorder resources so that namespaces and helmreleases are created before dependent resources.