### PR TITLE
feat(swl): add github-arc to talos3203

### DIFF
--- a/software-layer/k8s/apps/talos3203/github-arc/kustomization.yaml
+++ b/software-layer/k8s/apps/talos3203/github-arc/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: actions-runner-system
+resources:
+  - ../../base/github-arc/

--- a/software-layer/k8s/apps/talos3203/kustomization.yaml
+++ b/software-layer/k8s/apps/talos3203/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./github-arc/
   - ./home-assistant/
   - ./homer/
   - ./kube-prometheus-stack/


### PR DESCRIPTION
Should add gh actions runners on the talos3203 cluster before migration