### PR TITLE
fix(swl): add local dns suffix to github arc pods

### DIFF
--- a/software-layer/k8s/apps/base/github-arc/runnerdeployments.yaml
+++ b/software-layer/k8s/apps/base/github-arc/runnerdeployments.yaml
@@ -10,6 +10,8 @@ spec:
         options:
           - name: ndots
             value: '1'
+        searches:
+          - home.bcbrookman.com
       repository: bcbrookman/homeops
 
 ---


### PR DESCRIPTION
The Talos nodes don't have the local DNS search suffix configured and/or don't add it to pods automatically. Adding it to the github arc pod spec solves this problem regardless of the node configuration. And other pods probably shouldn't have it anyways.