### PR TITLE
fix(swl): use ssh url in flux gitrepo

### DIFF
--- a/software-layer/k8s/clusters/talos3203/flux-system/gotk-sync.yaml
+++ b/software-layer/k8s/clusters/talos3203/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 1m0s
   ref:
     branch: main
-  url: https://github.com/bcbrookman/homeops
+  url: ssh://git@github.com/bcbrookman/homeops
 
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1


### PR DESCRIPTION
To give flux write access to the repo using a deploy key, the gitrepo url needs to be an ssh url. It had inadvertently been changed to https when migrating to talos.