### PR TITLE
ci: allow system python package installs

### DIFF
--- a/.requirements/tasks.yaml
+++ b/.requirements/tasks.yaml
@@ -4,7 +4,10 @@ version: '3'
 run: once
 
 env:
-  PIP_OPTS: "--no-input --no-cache-dir --root-user-action=ignore --prefer-binary --upgrade"
+  PIP_OPTS: >-
+    --no-input --no-cache-dir --prefer-binary
+    --root-user-action=ignore --break-system-packages
+    --upgrade
 
 tasks:
   default:


### PR DESCRIPTION
Adds --break-system-packages option for Python package installations